### PR TITLE
Fix a minor bug.

### DIFF
--- a/errorify/error.py
+++ b/errorify/error.py
@@ -50,6 +50,7 @@ def readn(file, n):
         if len(clist) == n:
             start = True
             yield clist
+            clist = []
     yield clist
 
 


### PR DESCRIPTION
The original code produces an additional redundant batch when the number of data samples is divisible by the batch size.